### PR TITLE
Set proper spacing for the 'Jump to...' button

### DIFF
--- a/tight.css
+++ b/tight.css
@@ -259,3 +259,7 @@ body.loading::before {
 .p-channel_sidebar__static_list > div[role="presentation"]:first-child {
   height: 0 !important;
 }
+
+.p-channel_sidebar__jumper {
+  margin: 12px 0 12px 14px !important;
+}


### PR DESCRIPTION
The jumper button was left unstyled and appeared a bit odd. Set proper spacings for the button to match the interface.

### Previous:
![previous](https://user-images.githubusercontent.com/19777714/45963497-eb204280-c040-11e8-89b7-b54f4dacdc9d.png)

### Updated:
![improved](https://user-images.githubusercontent.com/19777714/45963522-f6736e00-c040-11e8-916e-8c90760aabdf.png)


